### PR TITLE
Functionality to Receive Image Data on the Server Computer

### DIFF
--- a/Comms/Mock/mock_server.py
+++ b/Comms/Mock/mock_server.py
@@ -18,6 +18,7 @@ The script continuously listens for messages from the HoloLens and processes the
 """
 
 import asyncio # Import the asyncio library for asynchronous I/O
+import socket # Import the socket library for determining IP address
 import concurrent.futures # Import the concurrent.futures library for thread-based parallelism
 import struct # Import the struct library for working with C-style data structures
 import time # Import the struct library for working with C-style data structures
@@ -29,6 +30,13 @@ torques = [0] * 6 # Initialize a list of 6 zeroes to store torque values for eac
 messages = ["DOWN"] # Initialize a list with the initial message "DOWN"
 executor = concurrent.futures.ThreadPoolExecutor(max_workers=1) # Create a ThreadPoolExecutor with a single worker
 
+def get_ip_address():
+    try:
+        hostname = socket.gethostname()
+        ip_address = socket.gethostbyname(hostname)
+        return ip_address
+    except:
+        return "Error: Unable to get IP address"
 
 def comm_robot():
     rtde_c = RTDEControlInterface("169.254.9.43") # Create a control interface with the robot's IP address
@@ -91,6 +99,8 @@ async def receive_image(reader: asyncio.StreamReader, writer: asyncio.StreamWrit
             break
 
 async def main():
+    print(f"Running on IP: {get_ip_address()}")  # Add this line
+
     loop = asyncio.get_running_loop()
     await asyncio.gather(
         comm_hololens(),


### PR DESCRIPTION
Added a functionality to receive image data sent by a writer object (from the asyncio module) on the mock_server.py code. I think this is a first step towards being able to communicate the force/displacement data to the Hololens.

I was able to get this working using an image-sender.py code which can be found in [this repo](https://github.com/malekinho8/2.12-camera-streaming) running on a client computer and running the mock_server.py script on a separate server computer.